### PR TITLE
use rfd for every OS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,12 +32,7 @@ open = "2"
 crates-index = { version = "0.18.0" }
 toml_edit = "0.6.0"
 anyhow = "1"
-
-[target.'cfg(any(target_os = "macos", target_os = "windows"))'.dependencies]
-rfd = "0.5.1"
-
-[target.'cfg(not(any(target_os = "macos", target_os = "windows")))'.dependencies]
-dialog = "0.3"
+rfd = { version = "0.7", default-features = false, features = [ "parent" ] }
 
 [build-dependencies]
 sixtyfps-build = { version = "0.1.4" }

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -653,30 +653,6 @@ fn apply_metadata(
     });
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
-fn show_open_dialog(manifest: Manifest) -> Manifest {
-    use dialog::DialogBox;
-
-    let mut dialog = dialog::FileSelection::new("Select a manifest (Cargo.toml)");
-    dialog
-        .title("Select a manifest")
-        .mode(dialog::FileSelectionMode::Open);
-
-    if let Some(directory) = manifest.directory() {
-        dialog.path(directory);
-    }
-
-    match dialog.show() {
-        Ok(Some(r)) => PathBuf::from(r).into(),
-        Ok(None) => manifest,
-        Err(e) => {
-            eprintln!("{}", e);
-            manifest
-        }
-    }
-}
-
-#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn show_open_dialog(manifest: Manifest) -> Manifest {
     let mut dialog = rfd::FileDialog::new();
     dialog = dialog.set_title("Select a manifest");


### PR DESCRIPTION
rfd 0.7 can now use the XDG Desktop Portal D-Bus API instead of
depending on GTK. The D-Bus API is handled by ashpd which uses
zbus, so this does not bring in any new C or C++ dependencies.